### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,6 +29,7 @@ rios0rios0.github.io/
 ├── tags/                     # Tag index pages (active, ctf, htb, machine, retired, sec)
 ├── timeline/                 # Timeline archive page
 ├── 404.html                  # Custom 404 error page
+├── CHANGELOG.md              # Release history and release process
 ├── CONTRIBUTING.md           # Contribution guidelines
 ├── LICENSE                   # License file
 ├── README.md                 # Project overview
@@ -88,6 +89,8 @@ Post images and assets go under `files/security/ctf/htb/m.<machine-name>/`.
 ## CI/CD Pipeline
 
 The site is deployed automatically to GitHub Pages from the `main` branch. No separate build workflow is required — GitHub Pages natively serves the static HTML files committed to the repository.
+
+A `release.yaml` workflow runs on pushes to `main` and delegates to the reusable `rios0rios0/pipelines` release workflow to create Git tags. See `CHANGELOG.md` for the release process: create a `bump/x.x.x` branch, move `[Unreleased]` entries under a versioned heading, merge to `main`, and a tag is created automatically.
 
 ## Coding Conventions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `.github/copilot-instructions.md` to add missing `CHANGELOG.md` to the repo structure tree and document the new `release.yaml` workflow in the CI/CD section
+
 ## [1.1.1] - 2026-04-28
 
 ### Changed


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.